### PR TITLE
feat: Add digital PDF signing for certificate confirmation responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ sems/create_sample_upload.py
 sems/backend/app/add_test_unmatched_records.py
 sems/grading_boundary_setting.ipynb
 .vscode/
+registration-portal/backend/certs/
+registration-portal/backend/test_certs/

--- a/registration-portal/backend/Dockerfile
+++ b/registration-portal/backend/Dockerfile
@@ -46,7 +46,7 @@ COPY ./pyproject.toml ./uv.lock ./alembic.ini  /app/
 COPY ./app /app/app
 
 COPY ./alembic /app/alembic
-
+COPY ./certs /app/certs
 
 # Sync the project
 # Ref: https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers

--- a/registration-portal/backend/app/config.py
+++ b/registration-portal/backend/app/config.py
@@ -41,6 +41,16 @@ class Settings(BaseSettings):
     express_service_multiplier: float = 1.5  # Multiplier for express service (e.g., 1.5x base price)
     # Certificate request file storage
     certificate_request_storage_path: str = "storage/certificate_requests"
+    # PDF signing settings
+    pdf_signing_enabled: bool = True  # Feature flag for PDF signing (set to True and configure certificate to enable)
+    pdf_signing_certificate_path: str = ""  # Path to certificate file (.pem, .p12, .pfx)
+    pdf_signing_key_path: str = ""  # Path to private key file (if separate from certificate)
+    pdf_signing_certificate_password: str = ""  # Password for certificate (if password-protected)
+    pdf_signing_certificate_chain_path: str = ""  # Optional: Path to certificate chain file (intermediate/root CAs) for better verification
+    pdf_signing_reason: str = "Certificate Confirmation Response"  # Signing reason (visible in signature properties)
+    pdf_signing_location: str = "Ghana"  # Signing location (visible in signature properties)
+    pdf_signing_contact_info: str = ""  # Contact information (visible in signature properties)
+    pdf_signing_organization: str = ""  # Organization name (for certificate metadata)
 
 
 class LoggingSettings(BaseSettings):

--- a/registration-portal/backend/app/scripts/certificate_manager.py
+++ b/registration-portal/backend/app/scripts/certificate_manager.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Unified CLI tool for certificate management operations."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from app.scripts.generate_signing_certificate import generate_certificate, save_p12_format, save_pem_format
+from app.services.pdf_signing_service import (
+    CertificateLoadError,
+    get_certificate_info,
+    validate_certificate,
+)
+
+
+def cmd_generate(args: argparse.Namespace) -> None:
+    """Generate a new certificate."""
+    try:
+        print("Generating certificate...")
+        private_key, cert = generate_certificate(
+            organization=args.organization,
+            country=args.country,
+            state=args.state,
+            locality=args.locality,
+            common_name=args.common_name,
+            validity_days=args.validity_days,
+            key_size=args.key_size,
+        )
+
+        if args.format == "pem":
+            # Determine output paths
+            if args.output_dir:
+                output_dir = Path(args.output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                cert_path = output_dir / f"{args.cert_name}.pem"
+                key_path = output_dir / f"{args.cert_name}_key.pem"
+            elif args.cert_output or args.key_output:
+                cert_path = Path(args.cert_output or f"{args.cert_name}.pem")
+                key_path = Path(args.key_output or f"{args.cert_name}_key.pem")
+            else:
+                # Default to current directory
+                cert_path = Path(f"{args.cert_name}.pem")
+                key_path = Path(f"{args.cert_name}_key.pem")
+
+            save_pem_format(private_key, cert, cert_path, key_path)
+        else:  # p12
+            if not args.password:
+                print("Error: --password is required for P12 format", file=sys.stderr)
+                sys.exit(1)
+
+            if args.output_dir:
+                output_dir = Path(args.output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                p12_path = output_dir / f"{args.cert_name}.p12"
+            else:
+                p12_path = Path(args.output or f"{args.cert_name}.p12")
+
+            save_p12_format(private_key, cert, p12_path, args.password)
+
+        print("\nCertificate generated successfully!")
+
+    except Exception as e:
+        print(f"Error generating certificate: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    """Validate a certificate."""
+    try:
+        result = validate_certificate(
+            cert_path=args.certificate,
+            key_path=args.key,
+            password=args.password,
+        )
+
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("Certificate Validation Results")
+            print("=" * 50)
+            if result["valid"]:
+                print("Status: ✓ VALID")
+            else:
+                print("Status: ✗ INVALID")
+
+            if result["errors"]:
+                print("\nErrors:")
+                for error in result["errors"]:
+                    print(f"  ✗ {error}")
+
+            if result["warnings"]:
+                print("\nWarnings:")
+                for warning in result["warnings"]:
+                    print(f"  ⚠ {warning}")
+
+            if result["info"]:
+                print("\nCertificate Information:")
+                for key, value in result["info"].items():
+                    print(f"  {key}: {value}")
+
+        sys.exit(0 if result["valid"] else 1)
+
+    except Exception as e:
+        print(f"Error validating certificate: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_info(args: argparse.Namespace) -> None:
+    """Display certificate information."""
+    try:
+        info = get_certificate_info(
+            cert_path=args.certificate,
+            key_path=args.key,
+            password=args.password,
+        )
+
+        if args.json:
+            print(json.dumps(info, indent=2, default=str))
+        else:
+            print("Certificate Information")
+            print("=" * 50)
+            print(f"\nSubject:")
+            for key, value in info["subject"].items():
+                if value:
+                    print(f"  {key}: {value}")
+
+            print(f"\nIssuer:")
+            for key, value in info["issuer"].items():
+                if value:
+                    print(f"  {key}: {value}")
+
+            print(f"\nValidity:")
+            print(f"  Not valid before: {info['validity']['not_valid_before']}")
+            print(f"  Not valid after: {info['validity']['not_valid_after']}")
+            print(f"  Currently valid: {'Yes' if info['validity']['is_valid'] else 'No'}")
+
+            print(f"\nTechnical Details:")
+            print(f"  Serial number: {info['serial_number']}")
+            print(f"  Version: {info['version']}")
+            print(f"  Key type: {info.get('key_type', 'Unknown')}")
+            if "key_size" in info:
+                print(f"  Key size: {info['key_size']} bits")
+
+            if info.get("extensions"):
+                print(f"\nExtensions:")
+                if "key_usage" in info["extensions"]:
+                    ku = info["extensions"]["key_usage"]
+                    print(f"  Key Usage:")
+                    print(f"    Digital Signature: {ku.get('digital_signature', False)}")
+                    print(f"    Content Commitment: {ku.get('content_commitment', False)}")
+
+    except CertificateLoadError as e:
+        print(f"Error loading certificate: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error getting certificate info: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_convert(args: argparse.Namespace) -> None:
+    """Convert certificate between formats."""
+    try:
+        from cryptography.hazmat.primitives.serialization import pkcs12, serialization
+
+        from app.services.pdf_signing_service import _load_certificate_p12, _load_certificate_pem
+
+        # Load source certificate
+        if args.input.lower().endswith((".p12", ".pfx")):
+            if not args.input_password:
+                print("Error: --input-password is required for P12/PFX input", file=sys.stderr)
+                sys.exit(1)
+            cert, private_key = _load_certificate_p12(args.input, args.input_password)
+        else:
+            cert, private_key = _load_certificate_pem(args.input, args.key, args.input_password)
+
+        # Save in target format
+        if args.output.lower().endswith((".p12", ".pfx")):
+            if not args.output_password:
+                print("Error: --output-password is required for P12/PFX output", file=sys.stderr)
+                sys.exit(1)
+
+            p12_data = pkcs12.serialize_key_and_certificates(
+                name=b"PDF Signing Certificate",
+                key=private_key,
+                cert=cert,
+                cas=None,
+                encryption_algorithm=serialization.BestAvailableEncryption(args.output_password.encode()),
+            )
+            with open(args.output, "wb") as f:
+                f.write(p12_data)
+            print(f"Certificate converted to P12 format: {args.output}")
+        else:
+            save_pem_format(private_key, cert, Path(args.output), Path(args.output.replace(".pem", "_key.pem")))
+            print(f"Certificate converted to PEM format: {args.output}")
+
+    except Exception as e:
+        print(f"Error converting certificate: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_test_sign(args: argparse.Namespace) -> None:
+    """Test signing a sample PDF."""
+    try:
+        from io import BytesIO
+
+        from reportlab.pdfgen import canvas
+
+        from app.services.pdf_signing_service import sign_pdf
+
+        buffer = BytesIO()
+        c = canvas.Canvas(buffer)
+        c.drawString(100, 750, "Test PDF for Certificate Signing")
+        c.drawString(100, 730, f"Generated at: {args.timestamp or 'now'}")
+        c.save()
+        test_pdf_bytes = buffer.getvalue()
+
+        # Sign the PDF
+        print("Signing test PDF...")
+        signed_pdf = sign_pdf(test_pdf_bytes, "Test Signer", "System Administrator")
+
+        # Save signed PDF
+        output_path = Path(args.output or "test_signed.pdf")
+        with open(output_path, "wb") as f:
+            f.write(signed_pdf)
+
+        print(f"Test PDF signed successfully: {output_path}")
+        print("You can now verify the signature in a PDF reader (Adobe Reader, Chrome, etc.)")
+
+    except Exception as e:
+        print(f"Error testing signature: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(description="Certificate management tool for PDF signing")
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # Generate command
+    gen_parser = subparsers.add_parser("generate", help="Generate a new certificate")
+    gen_parser.add_argument("--format", choices=["pem", "p12"], default="pem", help="Certificate format")
+    gen_parser.add_argument("--output-dir", type=str, help="Output directory for certificate files")
+    gen_parser.add_argument("--output", type=str, help="Output file path (for P12, overrides --output-dir)")
+    gen_parser.add_argument("--cert-output", type=str, help="Certificate output path (PEM, overrides --output-dir)")
+    gen_parser.add_argument("--key-output", type=str, help="Key output path (PEM, overrides --output-dir)")
+    gen_parser.add_argument("--cert-name", type=str, default="signing_cert", help="Base name for certificate files")
+    gen_parser.add_argument("--organization", type=str, default="PDF Signing Organization", help="Organization name")
+    gen_parser.add_argument("--country", type=str, default="GH", help="Country code")
+    gen_parser.add_argument("--state", type=str, help="State or province")
+    gen_parser.add_argument("--locality", type=str, help="Locality/city")
+    gen_parser.add_argument("--common-name", type=str, default="PDF Signing Certificate", help="Common name")
+    gen_parser.add_argument("--validity-days", type=int, default=365, help="Validity in days")
+    gen_parser.add_argument("--key-size", type=int, choices=[2048, 4096], default=2048, help="Key size")
+    gen_parser.add_argument("--password", type=str, help="Password for P12 format")
+    gen_parser.set_defaults(func=cmd_generate)
+
+    # Validate command
+    val_parser = subparsers.add_parser("validate", help="Validate a certificate")
+    val_parser.add_argument("--certificate", type=str, help="Certificate file path (uses settings if not provided)")
+    val_parser.add_argument("--key", type=str, help="Private key file path (PEM format only)")
+    val_parser.add_argument("--password", type=str, help="Certificate password")
+    val_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    val_parser.set_defaults(func=cmd_validate)
+
+    # Info command
+    info_parser = subparsers.add_parser("info", help="Display certificate information")
+    info_parser.add_argument("--certificate", type=str, help="Certificate file path (uses settings if not provided)")
+    info_parser.add_argument("--key", type=str, help="Private key file path (PEM format only)")
+    info_parser.add_argument("--password", type=str, help="Certificate password")
+    info_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    info_parser.set_defaults(func=cmd_info)
+
+    # Convert command
+    conv_parser = subparsers.add_parser("convert", help="Convert certificate between formats")
+    conv_parser.add_argument("--input", type=str, required=True, help="Input certificate file")
+    conv_parser.add_argument("--key", type=str, help="Private key file (for PEM input)")
+    conv_parser.add_argument("--input-password", type=str, help="Input file password")
+    conv_parser.add_argument("--output", type=str, required=True, help="Output certificate file")
+    conv_parser.add_argument("--output-password", type=str, help="Output file password (for P12)")
+    conv_parser.set_defaults(func=cmd_convert)
+
+    # Test sign command
+    test_parser = subparsers.add_parser("test-sign", help="Test signing a sample PDF")
+    test_parser.add_argument("--output", type=str, help="Output PDF file path")
+    test_parser.add_argument("--timestamp", type=str, help="Timestamp for test PDF")
+    test_parser.set_defaults(func=cmd_test_sign)
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/registration-portal/backend/app/scripts/generate_signing_certificate.py
+++ b/registration-portal/backend/app/scripts/generate_signing_certificate.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Script to generate self-signed certificates for PDF signing."""
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+
+def generate_certificate(
+    organization: str = "PDF Signing Organization",
+    country: str = "GH",
+    state: str | None = None,
+    locality: str | None = None,
+    common_name: str = "PDF Signing Certificate",
+    validity_days: int = 365,
+    key_size: int = 2048,
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """
+    Generate a self-signed certificate for PDF signing.
+
+    Args:
+        organization: Organization name
+        country: Country code (2 letters)
+        state: State or province name
+        locality: Locality/city name
+        common_name: Common name for the certificate
+        validity_days: Certificate validity period in days
+        key_size: RSA key size (2048 or 4096)
+
+    Returns:
+        Tuple of (private_key, certificate)
+    """
+    # Generate private key
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+
+    # Build certificate subject and issuer (self-signed)
+    name_attributes = [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, organization),
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+    ]
+
+    if state:
+        name_attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, state))
+    if locality:
+        name_attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, locality))
+
+    subject = issuer = x509.Name(name_attributes)
+
+    # Create certificate
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=validity_days))
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=True,  # Non-repudiation
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.EMAIL_PROTECTION]),  # Common for document signing
+            critical=False,
+        )
+        .sign(private_key, hashes.SHA256())
+    )
+
+    return private_key, cert
+
+
+def save_pem_format(private_key: rsa.RSAPrivateKey, cert: x509.Certificate, cert_path: Path, key_path: Path) -> None:
+    """Save certificate and key in PEM format."""
+    # Save certificate
+    with open(cert_path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+    # Save private key (unencrypted)
+    with open(key_path, "wb") as f:
+        f.write(
+            private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+    print(f"Certificate saved to: {cert_path}")
+    print(f"Private key saved to: {key_path}")
+
+
+def save_p12_format(
+    private_key: rsa.RSAPrivateKey, cert: x509.Certificate, p12_path: Path, password: str
+) -> None:
+    """Save certificate and key in P12/PFX format."""
+    from cryptography.hazmat.primitives.serialization import pkcs12
+
+    p12_data = pkcs12.serialize_key_and_certificates(
+        name=b"PDF Signing Certificate",
+        key=private_key,
+        cert=cert,
+        cas=None,  # No CA certificates for self-signed
+        encryption_algorithm=serialization.BestAvailableEncryption(password.encode()),
+    )
+
+    with open(p12_path, "wb") as f:
+        f.write(p12_data)
+
+    print(f"P12 certificate saved to: {p12_path}")
+    print(f"Password: {password}")
+
+
+def main() -> None:
+    """Main function to generate certificate."""
+    parser = argparse.ArgumentParser(description="Generate self-signed certificate for PDF signing")
+    parser.add_argument(
+        "--format",
+        choices=["pem", "p12"],
+        default="pem",
+        help="Certificate format (default: pem)",
+    )
+    parser.add_argument("--output-dir", type=str, help="Output directory for PEM format files")
+    parser.add_argument("--output", type=str, help="Output file path (for P12 format or custom PEM paths)")
+    parser.add_argument("--organization", type=str, default="PDF Signing Organization", help="Organization name")
+    parser.add_argument("--country", type=str, default="GH", help="Country code (2 letters)")
+    parser.add_argument("--state", type=str, help="State or province name")
+    parser.add_argument("--locality", type=str, help="Locality/city name")
+    parser.add_argument("--common-name", type=str, default="PDF Signing Certificate", help="Common name (CN)")
+    parser.add_argument("--validity-days", type=int, default=365, help="Certificate validity in days (default: 365)")
+    parser.add_argument("--key-size", type=int, choices=[2048, 4096], default=2048, help="RSA key size (default: 2048)")
+    parser.add_argument("--password", type=str, help="Password for P12 format (required for P12)")
+    parser.add_argument(
+        "--cert-name",
+        type=str,
+        default="signing_cert",
+        help="Base name for certificate files (PEM format only, default: signing_cert)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate P12 password requirement
+    if args.format == "p12" and not args.password:
+        print("Error: --password is required for P12 format", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        # Generate certificate
+        print("Generating certificate...")
+        private_key, cert = generate_certificate(
+            organization=args.organization,
+            country=args.country,
+            state=args.state,
+            locality=args.locality,
+            common_name=args.common_name,
+            validity_days=args.validity_days,
+            key_size=args.key_size,
+        )
+
+        # Determine output paths
+        if args.format == "pem":
+            if args.output_dir:
+                output_dir = Path(args.output_dir)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                cert_path = output_dir / f"{args.cert_name}.pem"
+                key_path = output_dir / f"{args.cert_name}_key.pem"
+            elif args.output:
+                # If output is specified, use it as cert path and derive key path
+                output_path = Path(args.output)
+                cert_path = output_path
+                key_path = output_path.parent / f"{output_path.stem}_key{output_path.suffix}"
+            else:
+                # Default to current directory
+                cert_path = Path(f"{args.cert_name}.pem")
+                key_path = Path(f"{args.cert_name}_key.pem")
+
+            save_pem_format(private_key, cert, cert_path, key_path)
+            print(f"\nCertificate Information:")
+            print(f"  Subject: {cert.subject}")
+            print(f"  Valid from: {cert.not_valid_before}")
+            print(f"  Valid until: {cert.not_valid_after}")
+            print(f"  Key size: {args.key_size} bits")
+
+        else:  # p12 format
+            if args.output:
+                p12_path = Path(args.output)
+            else:
+                p12_path = Path("signing_cert.p12")
+
+            p12_path.parent.mkdir(parents=True, exist_ok=True)
+            save_p12_format(private_key, cert, p12_path, args.password)
+            print(f"\nCertificate Information:")
+            print(f"  Subject: {cert.subject}")
+            print(f"  Valid from: {cert.not_valid_before}")
+            print(f"  Valid until: {cert.not_valid_after}")
+            print(f"  Key size: {args.key_size} bits")
+
+        print("\nCertificate generated successfully!")
+
+    except Exception as e:
+        print(f"Error generating certificate: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/registration-portal/backend/app/scripts/test_pdf_signing.py
+++ b/registration-portal/backend/app/scripts/test_pdf_signing.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Test script for PDF signing with certificate."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from app.services.pdf_signing_service import (
+    CertificateLoadError,
+    PdfSigningError,
+    get_certificate_info,
+    sign_pdf,
+    validate_certificate,
+)
+from app.scripts.generate_signing_certificate import generate_certificate, save_pem_format
+
+
+def create_test_pdf() -> bytes:
+    """Create a simple test PDF document."""
+    try:
+        from reportlab.pdfgen import canvas
+        from io import BytesIO
+
+        buffer = BytesIO()
+        c = canvas.Canvas(buffer)
+        c.drawString(100, 750, "Certificate Confirmation Response - Test Document")
+        c.drawString(100, 730, "This is a test PDF for certificate signing verification.")
+        c.drawString(100, 710, "The signature on this document can be verified in standard PDF readers.")
+        c.save()
+        return buffer.getvalue()
+    except ImportError:
+        # Fallback: create minimal PDF manually
+        # This is a very basic PDF structure
+        pdf_content = b"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 12 Tf 100 750 Td (Test PDF for Signing) Tj ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000300 00000 n
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+394
+%%EOF"""
+        return pdf_content
+
+
+def main() -> None:
+    """Main test function."""
+    parser = argparse.ArgumentParser(description="Test PDF signing with certificate")
+    parser.add_argument("--certificate", type=str, help="Certificate file path (uses settings if not provided)")
+    parser.add_argument("--key", type=str, help="Private key file path (PEM format only)")
+    parser.add_argument("--password", type=str, help="Certificate password")
+    parser.add_argument("--generate-cert", action="store_true", help="Generate a test certificate first")
+    parser.add_argument("--cert-dir", type=str, default="./test_certs", help="Directory for generated certificate")
+    parser.add_argument("--output", type=str, default="test_signed.pdf", help="Output signed PDF path")
+    parser.add_argument("--skip-verification", action="store_true", help="Skip signature verification step")
+
+    args = parser.parse_args()
+
+    cert_path = args.certificate
+    key_path = args.key
+    password = args.password
+
+    # Generate certificate if requested
+    if args.generate_cert:
+        print("Generating test certificate...")
+        try:
+            cert_dir = Path(args.cert_dir)
+            cert_dir.mkdir(parents=True, exist_ok=True)
+
+            private_key, cert = generate_certificate(
+                organization="Test Organization",
+                country="GH",
+                common_name="Test PDF Signing Certificate",
+                validity_days=365,
+            )
+
+            cert_path = str(cert_dir / "test_signing_cert.pem")
+            key_path = str(cert_dir / "test_signing_cert_key.pem")
+            save_pem_format(private_key, cert, Path(cert_path), Path(key_path))
+
+            print(f"Test certificate generated:")
+            print(f"  Certificate: {cert_path}")
+            print(f"  Private key: {key_path}")
+        except Exception as e:
+            print(f"Error generating certificate: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Validate certificate
+    if cert_path:
+        print("\nValidating certificate...")
+        try:
+            validation_result = validate_certificate(cert_path, key_path, password)
+            if validation_result["valid"]:
+                print("✓ Certificate is valid")
+                if validation_result["warnings"]:
+                    print("Warnings:")
+                    for warning in validation_result["warnings"]:
+                        print(f"  ⚠ {warning}")
+            else:
+                print("✗ Certificate validation failed:")
+                for error in validation_result["errors"]:
+                    print(f"  ✗ {error}")
+                sys.exit(1)
+        except Exception as e:
+            print(f"Error validating certificate: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("Using certificate from configuration...")
+
+    # Display certificate info
+    print("\nCertificate Information:")
+    try:
+        info = get_certificate_info(cert_path, key_path, password)
+        print(f"  Subject: {info['subject'].get('common_name') or info['subject'].get('organization', 'N/A')}")
+        print(f"  Valid from: {info['validity']['not_valid_before']}")
+        print(f"  Valid until: {info['validity']['not_valid_after']}")
+        print(f"  Key size: {info.get('key_size', 'Unknown')} bits")
+    except Exception as e:
+        print(f"  Warning: Could not get certificate info: {e}")
+
+    # Create test PDF
+    print("\nCreating test PDF...")
+    try:
+        test_pdf = create_test_pdf()
+        print(f"✓ Test PDF created ({len(test_pdf)} bytes)")
+    except Exception as e:
+        print(f"Error creating test PDF: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Sign PDF
+    print("\nSigning PDF...")
+    try:
+        signed_pdf = sign_pdf(test_pdf, "Test Signer", "System Administrator")
+        print(f"✓ PDF signed successfully ({len(signed_pdf)} bytes)")
+    except CertificateLoadError as e:
+        print(f"✗ Certificate error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except PdfSigningError as e:
+        print(f"✗ Signing error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"✗ Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Save signed PDF
+    output_path = Path(args.output)
+    try:
+        with open(output_path, "wb") as f:
+            f.write(signed_pdf)
+        print(f"✓ Signed PDF saved to: {output_path}")
+    except Exception as e:
+        print(f"Error saving signed PDF: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Verify signature (optional)
+    if not args.skip_verification:
+        print("\nVerifying signature...")
+        try:
+            from endesive.pdf import verify
+
+            (hashok, signatureok, certok) = verify(signed_pdf)
+            if hashok and signatureok and certok:
+                print("✓ Signature verification passed")
+                print("  - Hash: OK")
+                print("  - Signature: OK")
+                print("  - Certificate: OK")
+            else:
+                print("⚠ Signature verification results:")
+                print(f"  - Hash: {'OK' if hashok else 'FAILED'}")
+                print(f"  - Signature: {'OK' if signatureok else 'FAILED'}")
+                print(f"  - Certificate: {'OK' if certok else 'FAILED'}")
+        except ImportError:
+            print("⚠ Could not verify signature (endesive verify not available)")
+        except Exception as e:
+            print(f"⚠ Signature verification error: {e}")
+
+    print("\n" + "=" * 60)
+    print("Test completed successfully!")
+    print(f"\nYou can now open {output_path} in a PDF reader to verify the signature:")
+    print("  - Adobe Acrobat Reader: Open PDF → Signature Panel")
+    print("  - Chrome: Open PDF → Right-click → Document Properties")
+    print("  - Firefox: Open PDF → View → Signatures")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/registration-portal/backend/app/services/pdf_signing_service.py
+++ b/registration-portal/backend/app/services/pdf_signing_service.py
@@ -1,0 +1,594 @@
+"""Service for digitally signing PDF documents."""
+
+import io
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization import pkcs12
+from endesive.pdf import cms
+from pypdf import PdfReader
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class PdfSigningError(Exception):
+    """Raised when PDF signing fails."""
+
+    pass
+
+
+class CertificateLoadError(Exception):
+    """Raised when certificate/key loading fails."""
+
+    pass
+
+
+def _load_certificate_pem(cert_path: str, key_path: str | None = None, password: str | None = None) -> tuple[Any, Any]:
+    """
+    Load certificate and private key from PEM files.
+
+    Args:
+        cert_path: Path to certificate file (.pem, .crt)
+        key_path: Path to private key file (.key, .pem). If None, assumes cert_path contains both.
+        password: Password for encrypted private key (if applicable)
+
+    Returns:
+        Tuple of (certificate, private_key)
+    """
+    cert_file = Path(cert_path)
+    if not cert_file.exists():
+        raise CertificateLoadError(f"Certificate file not found: {cert_path}")
+
+    try:
+        # Load certificate
+        with open(cert_file, "rb") as f:
+            cert_data = f.read()
+
+        cert = x509.load_pem_x509_certificate(cert_data)
+
+        # Load private key
+        if key_path:
+            key_file = Path(key_path)
+            if not key_file.exists():
+                raise CertificateLoadError(f"Private key file not found: {key_path}")
+            with open(key_file, "rb") as f:
+                key_data = f.read()
+        else:
+            # Try to load key from same file
+            key_data = cert_data
+
+        # Try to load as unencrypted first
+        try:
+            private_key = serialization.load_pem_private_key(key_data, password=None)
+        except ValueError:
+            # If that fails, try with password
+            if password:
+                private_key = serialization.load_pem_private_key(
+                    key_data, password=password.encode() if isinstance(password, str) else password
+                )
+            else:
+                raise CertificateLoadError("Private key is encrypted but no password provided")
+
+        return cert, private_key
+    except Exception as e:
+        raise CertificateLoadError(f"Failed to load PEM certificate/key: {e}") from e
+
+
+def _load_certificate_p12(p12_path: str, password: str | None = None) -> tuple[Any, Any]:
+    """
+    Load certificate and private key from P12/PFX file.
+
+    Args:
+        p12_path: Path to P12/PFX file
+        password: Password for P12/PFX file
+
+    Returns:
+        Tuple of (certificate, private_key)
+    """
+    p12_file = Path(p12_path)
+    if not p12_file.exists():
+        raise CertificateLoadError(f"P12/PFX file not found: {p12_path}")
+
+    try:
+        with open(p12_file, "rb") as f:
+            p12_data = f.read()
+
+        p12_password = password.encode() if password and isinstance(password, str) else password
+
+        try:
+            private_key, certificate, additional_certificates = pkcs12.load_key_and_certificates(p12_data, p12_password)
+        except ValueError as e:
+            if "incorrect password" in str(e).lower() or "bad decrypt" in str(e).lower():
+                raise CertificateLoadError("Incorrect password for P12/PFX file") from e
+            raise CertificateLoadError(f"Failed to load P12/PFX file: {e}") from e
+
+        if not certificate:
+            raise CertificateLoadError("No certificate found in P12/PFX file")
+        if not private_key:
+            raise CertificateLoadError("No private key found in P12/PFX file")
+
+        return certificate, private_key
+    except CertificateLoadError:
+        raise
+    except Exception as e:
+        raise CertificateLoadError(f"Failed to load P12/PFX certificate: {e}") from e
+
+
+def _load_certificate_chain(chain_path: str | None) -> list[Any] | None:
+    """
+    Load certificate chain from file.
+
+    Args:
+        chain_path: Path to certificate chain file (PEM format)
+
+    Returns:
+        List of certificates in chain, or None if not provided
+    """
+    if not chain_path:
+        return None
+
+    chain_file = Path(chain_path)
+    if not chain_file.exists():
+        logger.warning(f"Certificate chain file not found: {chain_path}. Continuing without chain.")
+        return None
+
+    try:
+        with open(chain_file, "rb") as f:
+            chain_data = f.read()
+
+        # Load all certificates from the chain file
+        certificates = []
+        for cert_pem in chain_data.split(b"-----BEGIN CERTIFICATE-----"):
+            if cert_pem.strip():
+                cert_pem = b"-----BEGIN CERTIFICATE-----" + cert_pem
+                try:
+                    cert = x509.load_pem_x509_certificate(cert_pem)
+                    certificates.append(cert)
+                except Exception:
+                    continue
+
+        if not certificates:
+            logger.warning(f"No certificates found in chain file: {chain_path}")
+            return None
+
+        logger.info(f"Loaded {len(certificates)} certificates from chain file")
+        return certificates
+    except Exception as e:
+        logger.warning(f"Failed to load certificate chain: {e}. Continuing without chain.")
+        return None
+
+
+def sign_pdf(pdf_bytes: bytes, signer_name: str, signer_title: str | None = None) -> bytes:
+    """
+    Sign a PDF document with a digital signature.
+
+    Args:
+        pdf_bytes: Unsigned PDF file as bytes
+        signer_name: Name of the signer
+        signer_title: Optional title/position of the signer
+
+    Returns:
+        Signed PDF file as bytes
+
+    Raises:
+        PdfSigningError: If signing fails
+        CertificateLoadError: If certificate/key cannot be loaded
+    """
+    if not settings.pdf_signing_enabled:
+        raise PdfSigningError("PDF signing is not enabled. Set PDF_SIGNING_ENABLED=true to enable.")
+
+    if not settings.pdf_signing_certificate_path:
+        raise CertificateLoadError("PDF signing certificate path is not configured")
+
+    # Validate certificate before signing
+    validation_result = validate_certificate()
+    if not validation_result["valid"]:
+        error_msg = "Certificate validation failed: " + "; ".join(validation_result["errors"])
+        raise CertificateLoadError(error_msg)
+    if validation_result["warnings"]:
+        for warning in validation_result["warnings"]:
+            logger.warning(f"Certificate warning: {warning}")
+
+    try:
+        # Load certificate and private key
+        cert_path = settings.pdf_signing_certificate_path
+        cert_path_lower = cert_path.lower()
+
+        if cert_path_lower.endswith((".p12", ".pfx")):
+            # P12/PFX format
+            cert, private_key = _load_certificate_p12(cert_path, settings.pdf_signing_certificate_password)
+        else:
+            # PEM format
+            cert, private_key = _load_certificate_pem(
+                cert_path, settings.pdf_signing_key_path, settings.pdf_signing_certificate_password
+            )
+
+        # Load certificate chain if available
+        cert_chain = _load_certificate_chain(settings.pdf_signing_certificate_chain_path)
+
+        # Prepare signature metadata
+        signer_info = signer_name
+        if signer_title:
+            signer_info = f"{signer_name}, {signer_title}"
+
+        # Build certificate chain for endesive
+        # endesive expects:
+        #   cert: the signing certificate (single certificate)
+        #   othercerts: list of additional certificates in the chain (intermediate and root CAs)
+        othercerts = cert_chain if cert_chain else []
+
+        # Verify PDF is readable before signing
+        pdf_reader = None
+        try:
+            pdf_reader = PdfReader(io.BytesIO(pdf_bytes))
+            num_pages = len(pdf_reader.pages)
+            if num_pages == 0:
+                raise PdfSigningError("PDF has no pages and cannot be signed")
+            logger.debug(f"PDF verified: {num_pages} pages, {len(pdf_bytes)} bytes")
+        except Exception as e:
+            raise PdfSigningError(f"PDF cannot be read and may be corrupted: {e}") from e
+
+        # Prepare signing parameters
+        # Use simple datetime format - endesive will format it correctly for PDF
+        # Format: YYYYMMDDHHmmSS (endesive handles the D: prefix and timezone internally)
+        signing_date = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+
+        dct = {
+            # Signature flags: 1 = signatures exist, 2 = append only
+            # Set to 3 only if document already has signatures - for new signatures, omit or set to 1
+            "sigflags": 1,  # 1 = signatures exist (we're adding one)
+            "contact": settings.pdf_signing_contact_info or "",
+            "location": settings.pdf_signing_location or "Ghana",
+            "reason": settings.pdf_signing_reason or "Certificate Confirmation Response",
+            "signingdate": signing_date,
+            "signer": signer_info,
+        }
+
+        # Add organization if configured
+        if settings.pdf_signing_organization:
+            dct["organization"] = settings.pdf_signing_organization
+
+        # Sign the PDF using endesive
+        # endesive.cms.sign expects: datau (unsigned data), udct (signature dictionary), key, cert, othercerts, algomd
+        # algomd is the hash/digest algorithm (e.g., "sha256", "sha384", "sha512"), not the signing algorithm
+        try:
+            # Log the input PDF size for debugging
+            logger.debug(f"Signing PDF: {len(pdf_bytes)} bytes, {len(pdf_reader.pages)} pages")
+
+            # Call endesive cms.sign with proper error handling
+            # cms.sign should return the full signed PDF (or signature data to append)
+            try:
+                signature_data = cms.sign(
+                    datau=pdf_bytes,  # Use original PDF bytes - endesive needs the original structure
+                    udct=dct,  # Signature dictionary (use udct for cms.sign)
+                    key=private_key,
+                    cert=cert,  # Signing certificate (single certificate, not a list)
+                    othercerts=othercerts,  # Certificate chain (list of intermediate and root CAs)
+                    algomd="sha256",  # Hash/digest algorithm (sha256, sha384, or sha512)
+                )
+
+                # Check if we got a full PDF or just signature data
+                # If it starts with %PDF, it's the full signed PDF
+                # Otherwise, it might be signature data that needs to be appended
+                if signature_data.startswith(b"%PDF"):
+                    # Full signed PDF
+                    signed_pdf_bytes = signature_data
+                elif len(signature_data) > len(pdf_bytes) * 0.9:
+                    # Large data, likely full PDF even without header
+                    signed_pdf_bytes = signature_data
+                else:
+                    # Small data, likely just signature - append to original PDF
+                    # This is the incremental update approach
+                    signed_pdf_bytes = pdf_bytes + signature_data
+                    logger.info("Appended signature data to original PDF (incremental update)")
+
+            except Exception as sign_error:
+                # Log the full error for debugging
+                logger.error(f"Endesive cms.sign raised exception: {sign_error}", exc_info=True)
+                raise PdfSigningError(f"Endesive signing failed: {sign_error}") from sign_error
+            except Exception as sign_error:
+                # Log the full error for debugging
+                logger.error(f"Endesive pdf.cms.sign raised exception: {sign_error}", exc_info=True)
+                raise PdfSigningError(f"Endesive signing failed: {sign_error}") from sign_error
+
+            # Log what we got back
+            logger.debug(f"Endesive returned: {len(signed_pdf_bytes)} bytes, starts with: {signed_pdf_bytes[:50]}")
+
+            # Basic validation: check that we got bytes back
+            if not signed_pdf_bytes:
+                raise PdfSigningError("Endesive returned empty bytes - signing failed")
+
+            # Check if PDF header exists (might have leading whitespace)
+            pdf_header_pos = signed_pdf_bytes.find(b"%PDF")
+            if pdf_header_pos == -1:
+                # No PDF header found - this is definitely wrong
+                raise PdfSigningError(
+                    f"Endesive returned {len(signed_pdf_bytes)} bytes with no %PDF header. "
+                    f"Got: {signed_pdf_bytes[:200]}"
+                )
+
+            # If PDF header is not at the start, strip leading bytes
+            if pdf_header_pos > 0:
+                logger.warning(f"PDF header found at position {pdf_header_pos}, stripping leading {pdf_header_pos} bytes")
+                signed_pdf_bytes = signed_pdf_bytes[pdf_header_pos:]
+
+            # Check if we got a full PDF or just signature data
+            # If it's too small, it might be just the signature - this shouldn't happen with cms.sign
+            if len(signed_pdf_bytes) < len(pdf_bytes) * 0.1:
+                raise PdfSigningError(
+                    f"Signed PDF size ({len(signed_pdf_bytes)}) is too small compared to original ({len(pdf_bytes)}). "
+                    f"This suggests the PDF may be corrupted or endesive returned unexpected data."
+                )
+
+            # Verify PDF structure by checking if it now starts with %PDF
+            if not signed_pdf_bytes.startswith(b"%PDF"):
+                raise PdfSigningError(f"Signed PDF does not start with %PDF header after processing. Got: {signed_pdf_bytes[:100]}")
+
+            logger.info(f"PDF signed successfully: {len(signed_pdf_bytes)} bytes (original: {len(pdf_bytes)} bytes)")
+
+        except Exception as e:
+            raise PdfSigningError(f"Failed to sign PDF: {e}") from e
+
+        logger.info(f"PDF signed successfully by {signer_info}")
+        return signed_pdf_bytes
+
+    except CertificateLoadError:
+        raise
+    except PdfSigningError:
+        raise
+    except Exception as e:
+        raise PdfSigningError(f"Unexpected error during PDF signing: {e}") from e
+
+
+def validate_certificate(
+    cert_path: str | None = None,
+    key_path: str | None = None,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """
+    Validate a certificate for PDF signing.
+
+    Args:
+        cert_path: Path to certificate file (uses settings if None)
+        key_path: Path to private key file (uses settings if None, PEM format only)
+        password: Password for certificate (uses settings if None)
+
+    Returns:
+        Dictionary with validation results:
+        {
+            "valid": bool,
+            "errors": list[str],
+            "warnings": list[str],
+            "info": dict[str, Any]
+        }
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: dict[str, Any] = {}
+
+    # Use settings if paths not provided
+    if cert_path is None:
+        cert_path = settings.pdf_signing_certificate_path
+    if key_path is None:
+        key_path = settings.pdf_signing_key_path
+    if password is None:
+        password = settings.pdf_signing_certificate_password
+
+    if not cert_path:
+        return {
+            "valid": False,
+            "errors": ["Certificate path not configured"],
+            "warnings": [],
+            "info": {},
+        }
+
+    try:
+        # Load certificate and key
+        cert_path_lower = cert_path.lower()
+        if cert_path_lower.endswith((".p12", ".pfx")):
+            cert, private_key = _load_certificate_p12(cert_path, password)
+        else:
+            cert, private_key = _load_certificate_pem(cert_path, key_path, password)
+
+        # Extract certificate information
+        info["subject"] = str(cert.subject)
+        info["issuer"] = str(cert.issuer)
+        info["serial_number"] = str(cert.serial_number)
+        # Use UTC-aware datetime methods if available (newer cryptography), fallback to naive for compatibility
+        if hasattr(cert, "not_valid_before_utc"):
+            not_valid_before = cert.not_valid_before_utc
+            not_valid_after = cert.not_valid_after_utc
+            # Use timezone-aware datetime for comparison
+            now = datetime.now(timezone.utc)
+        else:
+            # Fallback for older cryptography versions (deprecated but still works)
+            not_valid_before = cert.not_valid_before
+            not_valid_after = cert.not_valid_after
+            # Use naive datetime for comparison
+            now = datetime.utcnow()
+
+        info["not_valid_before"] = not_valid_before.isoformat()
+        info["not_valid_after"] = not_valid_after.isoformat()
+
+        # Check validity dates
+        if not_valid_after < now:
+            errors.append(f"Certificate expired on {not_valid_after.isoformat()}")
+        elif not_valid_before > now:
+            errors.append(f"Certificate not yet valid (valid from {not_valid_before.isoformat()})")
+        else:
+            days_until_expiry = (not_valid_after - now).days
+            info["days_until_expiry"] = days_until_expiry
+            if days_until_expiry < 30:
+                warnings.append(f"Certificate expires in {days_until_expiry} days")
+
+        # Check key usage
+        try:
+            key_usage = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.KEY_USAGE).value
+            if not key_usage.digital_signature:
+                errors.append("Certificate does not have Digital Signature key usage")
+            if not key_usage.content_commitment:
+                warnings.append("Certificate does not have Non-Repudiation (Content Commitment) key usage")
+        except x509.ExtensionNotFound:
+            warnings.append("Certificate does not have Key Usage extension")
+
+        # Check key size
+        if hasattr(private_key, "key_size"):
+            key_size = private_key.key_size
+            info["key_size"] = key_size
+            if key_size < 2048:
+                errors.append(f"Key size ({key_size} bits) is less than recommended minimum (2048 bits)")
+            elif key_size == 2048:
+                warnings.append("Consider using 4096-bit key for production")
+        else:
+            warnings.append("Could not determine key size")
+
+        # Verify key matches certificate
+        try:
+            # Try to verify the certificate's public key matches the private key
+            public_key = cert.public_key()
+            # This is a basic check - in practice, we'd do a cryptographic verification
+            if hasattr(public_key, "key_size") and hasattr(private_key, "key_size"):
+                if public_key.key_size != private_key.key_size:
+                    errors.append("Public key and private key sizes do not match")
+        except Exception:
+            warnings.append("Could not verify key-certificate match")
+
+        # Check certificate chain if configured
+        if settings.pdf_signing_certificate_chain_path:
+            chain = _load_certificate_chain(settings.pdf_signing_certificate_chain_path)
+            if chain:
+                info["chain_certificates"] = len(chain)
+            else:
+                warnings.append("Certificate chain file specified but could not be loaded")
+
+    except CertificateLoadError as e:
+        errors.append(f"Failed to load certificate: {str(e)}")
+    except Exception as e:
+        errors.append(f"Unexpected error during validation: {str(e)}")
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+    }
+
+
+def get_certificate_info(cert_path: str | None = None, key_path: str | None = None, password: str | None = None) -> dict[str, Any]:
+    """
+    Get detailed information about a certificate.
+
+    Args:
+        cert_path: Path to certificate file (uses settings if None)
+        key_path: Path to private key file (uses settings if None, PEM format only)
+        password: Password for certificate (uses settings if None)
+
+    Returns:
+        Dictionary with certificate information
+    """
+    # Use settings if paths not provided
+    if cert_path is None:
+        cert_path = settings.pdf_signing_certificate_path
+    if key_path is None:
+        key_path = settings.pdf_signing_key_path
+    if password is None:
+        password = settings.pdf_signing_certificate_password
+
+    if not cert_path:
+        raise CertificateLoadError("Certificate path not configured")
+
+    # Load certificate
+    cert_path_lower = cert_path.lower()
+    if cert_path_lower.endswith((".p12", ".pfx")):
+        cert, private_key = _load_certificate_p12(cert_path, password)
+    else:
+        cert, private_key = _load_certificate_pem(cert_path, key_path, password)
+
+    # Use UTC-aware datetime if available
+    if hasattr(cert, "not_valid_before_utc"):
+        not_valid_before_info = cert.not_valid_before_utc
+        not_valid_after_info = cert.not_valid_after_utc
+        # Use timezone-aware datetime for comparison
+        now = datetime.now(timezone.utc)
+    else:
+        not_valid_before_info = cert.not_valid_before
+        not_valid_after_info = cert.not_valid_after
+        # Use naive datetime for comparison
+        now = datetime.utcnow()
+
+    info: dict[str, Any] = {
+        "subject": {
+            "common_name": None,
+            "organization": None,
+            "country": None,
+            "state": None,
+            "locality": None,
+        },
+        "issuer": {
+            "common_name": None,
+            "organization": None,
+            "country": None,
+        },
+        "validity": {
+            "not_valid_before": not_valid_before_info.isoformat(),
+            "not_valid_after": not_valid_after_info.isoformat(),
+            "is_valid": not_valid_before_info <= now <= not_valid_after_info,
+        },
+        "serial_number": str(cert.serial_number),
+        "version": cert.version.name,
+    }
+
+    # Extract subject attributes
+    for attr in cert.subject:
+        if attr.oid == x509.oid.NameOID.COMMON_NAME:
+            info["subject"]["common_name"] = attr.value
+        elif attr.oid == x509.oid.NameOID.ORGANIZATION_NAME:
+            info["subject"]["organization"] = attr.value
+        elif attr.oid == x509.oid.NameOID.COUNTRY_NAME:
+            info["subject"]["country"] = attr.value
+        elif attr.oid == x509.oid.NameOID.STATE_OR_PROVINCE_NAME:
+            info["subject"]["state"] = attr.value
+        elif attr.oid == x509.oid.NameOID.LOCALITY_NAME:
+            info["subject"]["locality"] = attr.value
+
+    # Extract issuer attributes
+    for attr in cert.issuer:
+        if attr.oid == x509.oid.NameOID.COMMON_NAME:
+            info["issuer"]["common_name"] = attr.value
+        elif attr.oid == x509.oid.NameOID.ORGANIZATION_NAME:
+            info["issuer"]["organization"] = attr.value
+        elif attr.oid == x509.oid.NameOID.COUNTRY_NAME:
+            info["issuer"]["country"] = attr.value
+
+    # Key information
+    if hasattr(private_key, "key_size"):
+        info["key_size"] = private_key.key_size
+        info["key_type"] = "RSA"
+    else:
+        info["key_type"] = "Unknown"
+
+    # Extensions
+    info["extensions"] = {}
+    try:
+        key_usage = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.KEY_USAGE).value
+        info["extensions"]["key_usage"] = {
+            "digital_signature": key_usage.digital_signature,
+            "content_commitment": key_usage.content_commitment,
+            "key_encipherment": key_usage.key_encipherment,
+        }
+    except x509.ExtensionNotFound:
+        pass
+
+    try:
+        ext_key_usage = cert.extensions.get_extension_for_oid(x509.oid.ExtensionOID.EXTENDED_KEY_USAGE).value
+        info["extensions"]["extended_key_usage"] = [str(oid) for oid in ext_key_usage]
+    except x509.ExtensionNotFound:
+        pass
+
+    return info

--- a/registration-portal/backend/docs/CERTIFICATE_SETUP.md
+++ b/registration-portal/backend/docs/CERTIFICATE_SETUP.md
@@ -1,0 +1,372 @@
+# Certificate Setup Guide for PDF Signing
+
+This guide explains how to set up digital certificates for PDF signing in the certificate confirmation response system.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Certificate Types](#certificate-types)
+3. [Certificate Generation](#certificate-generation)
+4. [Configuration](#configuration)
+5. [Certificate Formats](#certificate-formats)
+6. [Production Recommendations](#production-recommendations)
+7. [Troubleshooting](#troubleshooting)
+8. [Certificate Renewal](#certificate-renewal)
+
+## Overview
+
+The PDF signing system uses digital certificates to cryptographically sign PDF documents. When a certificate confirmation response is signed, the PDF is embedded with a digital signature that can be verified by recipients using standard PDF readers.
+
+### Key Concepts
+
+- **Digital Signature**: A cryptographic signature that proves the document's authenticity and integrity
+- **Certificate**: Contains the public key and identity information
+- **Private Key**: Used to create the signature (must be kept secret)
+- **Certificate Chain**: Intermediate and root certificates for CA-signed certificates
+
+## Certificate Types
+
+### Self-Signed Certificates
+
+**Use Case**: Development, testing, internal use
+
+**Pros**:
+- Free to generate
+- Quick to set up
+- No external dependencies
+
+**Cons**:
+- Recipients see "Unknown Trust" warning
+- Requires manual trust by recipients
+- Not suitable for official/official documents
+
+### CA-Signed Certificates
+
+**Use Case**: Production, official documents
+
+**Pros**:
+- Automatically trusted by PDF readers
+- Better user experience
+- Professional appearance
+
+**Cons**:
+- May require purchasing from a Certificate Authority
+- Additional setup and cost
+- Certificate expiration management
+
+## Certificate Generation
+
+### Using the Generation Script
+
+The easiest way to generate a certificate is using the provided script:
+
+```bash
+# Generate PEM format (separate certificate and key files)
+python app/scripts/generate_signing_certificate.py \
+  --format pem \
+  --output-dir ./certs \
+  --organization "Your Organization Name" \
+  --country GH \
+  --state "Greater Accra" \
+  --locality "Accra" \
+  --common-name "PDF Signing Certificate" \
+  --validity-days 365 \
+  --key-size 2048
+
+# Generate P12 format (single password-protected file)
+python app/scripts/generate_signing_certificate.py \
+  --format p12 \
+  --output ./certs/signing.p12 \
+  --password "your_secure_password" \
+  --organization "Your Organization Name" \
+  --country GH \
+  --validity-days 365
+```
+
+### Using the Certificate Manager
+
+The unified certificate manager provides multiple operations:
+
+```bash
+# Generate certificate
+python app/scripts/certificate_manager.py generate \
+  --format pem \
+  --organization "Your Organization" \
+  --country GH \
+  --validity-days 365
+
+# Validate certificate
+python app/scripts/certificate_manager.py validate \
+  --certificate ./certs/signing_cert.pem \
+  --key ./certs/signing_cert_key.pem
+
+# Display certificate information
+python app/scripts/certificate_manager.py info \
+  --certificate ./certs/signing_cert.pem \
+  --key ./certs/signing_cert_key.pem
+
+# Convert between formats
+python app/scripts/certificate_manager.py convert \
+  --input ./certs/signing_cert.pem \
+  --key ./certs/signing_cert_key.pem \
+  --output ./certs/signing.p12 \
+  --output-password "password"
+```
+
+### Using OpenSSL (Alternative)
+
+If you prefer using OpenSSL directly:
+
+```bash
+# Generate self-signed certificate (PEM format)
+openssl req -x509 -newkey rsa:2048 \
+  -keyout signing_key.pem \
+  -out signing_cert.pem \
+  -days 365 \
+  -nodes \
+  -subj "/C=GH/ST=Greater Accra/L=Accra/O=Your Organization/CN=PDF Signing Certificate"
+
+# Convert to P12 format
+openssl pkcs12 -export \
+  -out signing.p12 \
+  -inkey signing_key.pem \
+  -in signing_cert.pem \
+  -name "PDF Signing Certificate" \
+  -passout pass:your_password
+```
+
+## Configuration
+
+### Environment Variables
+
+Configure the certificate in your `.env` file or environment:
+
+```bash
+# Enable PDF signing
+PDF_SIGNING_ENABLED=true
+
+# Certificate configuration (PEM format)
+PDF_SIGNING_CERTIFICATE_PATH=./certs/signing_cert.pem
+PDF_SIGNING_KEY_PATH=./certs/signing_cert_key.pem
+PDF_SIGNING_CERTIFICATE_PASSWORD=
+
+# OR Certificate configuration (P12 format)
+PDF_SIGNING_CERTIFICATE_PATH=./certs/signing.p12
+PDF_SIGNING_CERTIFICATE_PASSWORD=your_password
+
+# Optional: Certificate chain (for CA-signed certificates)
+PDF_SIGNING_CERTIFICATE_CHAIN_PATH=./certs/chain.pem
+
+# Signature metadata
+PDF_SIGNING_REASON=Certificate Confirmation Response
+PDF_SIGNING_LOCATION=Ghana
+PDF_SIGNING_CONTACT_INFO=contact@example.com
+PDF_SIGNING_ORGANIZATION=Your Organization Name
+```
+
+### Configuration in config.py
+
+The settings are defined in `app/config.py` and can be overridden via environment variables (using pydantic-settings).
+
+## Certificate Formats
+
+### PEM Format
+
+**Structure**: Two separate files
+- Certificate file: `.pem`, `.crt`
+- Private key file: `.pem`, `.key`
+
+**Configuration**:
+```bash
+PDF_SIGNING_CERTIFICATE_PATH=./certs/signing_cert.pem
+PDF_SIGNING_KEY_PATH=./certs/signing_cert_key.pem
+```
+
+**Pros**:
+- Easy to inspect (text format)
+- Can encrypt key separately
+- Standard format
+
+**Cons**:
+- Two files to manage
+- Key must be kept secure
+
+### P12/PFX Format
+
+**Structure**: Single password-protected file containing both certificate and key
+
+**Configuration**:
+```bash
+PDF_SIGNING_CERTIFICATE_PATH=./certs/signing.p12
+PDF_SIGNING_CERTIFICATE_PASSWORD=your_password
+```
+
+**Pros**:
+- Single file
+- Password-protected
+- Common in enterprise environments
+
+**Cons**:
+- Binary format (harder to inspect)
+- Password required
+
+## Production Recommendations
+
+### Certificate Requirements
+
+1. **Key Size**: Use 4096-bit RSA keys for production (2048-bit minimum)
+2. **Validity Period**: Set appropriate validity (1-3 years typical)
+3. **CA-Signed**: Use certificates from a trusted Certificate Authority
+4. **Certificate Chain**: Include intermediate and root certificates
+
+### Security Best Practices
+
+1. **Storage**:
+   - Store certificates in secure location (not in repository)
+   - Use environment variables or secrets management
+   - Restrict file permissions (chmod 600 for keys)
+
+2. **Access Control**:
+   - Limit access to certificate files
+   - Use password-protected P12 files
+   - Rotate certificates before expiration
+
+3. **Monitoring**:
+   - Monitor certificate expiration dates
+   - Set up alerts for upcoming expirations
+   - Test certificate renewal process
+
+### Example Production Setup
+
+```bash
+# Generate production certificate (4096-bit, 3 years)
+python app/scripts/generate_signing_certificate.py \
+  --format p12 \
+  --output /secure/certs/production_signing.p12 \
+  --password "$(openssl rand -base64 32)" \
+  --organization "Your Organization" \
+  --country GH \
+  --validity-days 1095 \
+  --key-size 4096
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Certificate Not Found
+
+**Error**: `Certificate file not found`
+
+**Solution**:
+- Verify the path in `PDF_SIGNING_CERTIFICATE_PATH`
+- Check file permissions
+- Ensure path is absolute or relative to application directory
+
+#### Invalid Password
+
+**Error**: `Incorrect password for P12/PFX file`
+
+**Solution**:
+- Verify `PDF_SIGNING_CERTIFICATE_PASSWORD` is correct
+- Check for extra spaces or special characters
+- Try loading certificate manually to verify password
+
+#### Certificate Expired
+
+**Error**: `Certificate expired`
+
+**Solution**:
+- Generate a new certificate
+- Update configuration with new certificate path
+- Consider setting up automatic renewal alerts
+
+#### Key Usage Invalid
+
+**Error**: `Certificate does not have Digital Signature key usage`
+
+**Solution**:
+- Regenerate certificate with proper key usage
+- Use the provided generation script (automatically sets correct usage)
+
+#### Signature Verification Fails
+
+**Issue**: Recipients cannot verify signature
+
+**Solutions**:
+- For self-signed: Recipients need to manually trust the certificate
+- For CA-signed: Ensure certificate chain is included
+- Provide certificate file for recipients to import
+
+### Testing Certificate
+
+Use the test script to verify your certificate setup:
+
+```bash
+python app/scripts/test_pdf_signing.py \
+  --certificate ./certs/signing_cert.pem \
+  --key ./certs/signing_cert_key.pem \
+  --output test_signed.pdf
+```
+
+This will:
+1. Validate the certificate
+2. Create a test PDF
+3. Sign the PDF
+4. Verify the signature
+5. Save the signed PDF for manual verification
+
+## Certificate Renewal
+
+### Before Expiration
+
+1. **Monitor Expiration**: Check certificate validity regularly
+   ```bash
+   python app/scripts/certificate_manager.py validate
+   ```
+
+2. **Generate New Certificate**: Create replacement certificate
+   ```bash
+   python app/scripts/generate_signing_certificate.py \
+     --format p12 \
+     --output ./certs/signing_new.p12 \
+     --password "new_password" \
+     --validity-days 365
+   ```
+
+3. **Test New Certificate**: Verify it works
+   ```bash
+   python app/scripts/test_pdf_signing.py \
+     --certificate ./certs/signing_new.p12 \
+     --password "new_password"
+   ```
+
+4. **Update Configuration**: Update environment variables
+   ```bash
+   PDF_SIGNING_CERTIFICATE_PATH=./certs/signing_new.p12
+   PDF_SIGNING_CERTIFICATE_PASSWORD=new_password
+   ```
+
+5. **Restart Application**: Reload configuration
+
+### After Expiration
+
+If certificate has already expired:
+
+1. Generate new certificate immediately
+2. Update configuration
+3. Re-sign any critical documents if needed
+4. Set up monitoring to prevent future expiration
+
+## Additional Resources
+
+- [Cryptography Library Documentation](https://cryptography.io/)
+- [OpenSSL Documentation](https://www.openssl.org/docs/)
+- [PDF Digital Signatures (Adobe)](https://www.adobe.com/devnet-docs/acrobatetk/tools/DigSig/overview.html)
+
+## Support
+
+For issues or questions:
+1. Check certificate validation: `python app/scripts/certificate_manager.py validate`
+2. Review application logs for detailed error messages
+3. Test with the test script: `python app/scripts/test_pdf_signing.py`

--- a/registration-portal/backend/pyproject.toml
+++ b/registration-portal/backend/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "cachetools>=6.2.4",
     "httpx>=0.28.1",
     "alembic-postgresql-enum>=1.8.0",
+    "asn1crypto>=1.5.1",
+    "cryptography>=46.0.3",
+    "endesive>=2.19.2",
+    "pypdf>=6.5.0",
+    "requests>=2.32.0",
 ]
 
 [dependency-groups]

--- a/registration-portal/backend/uv.lock
+++ b/registration-portal/backend/uv.lock
@@ -85,6 +85,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -575,6 +584,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "endesive"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/af/4722abf8cf92ffdb4a60d5bcc4e1f33bd420b8853586493b1c9ab74d8f38/endesive-2.19.2-py3-none-any.whl", hash = "sha256:4a209419c384249f96b517642159595fd656bedcb56a532a9ed967e825caccdc", size = 349164, upload-time = "2025-11-11T13:32:16.213Z" },
 ]
 
 [[package]]
@@ -1579,6 +1596,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/9b/db1056a54eda8cd44f9e5128e87e1142cb328295dad92bbec0d39f251641/pypdf-6.5.0.tar.gz", hash = "sha256:9e78950906380ae4f2ce1d9039e9008098ba6366a4d9c7423c4bdbd6e6683404", size = 5277655, upload-time = "2025-12-21T11:07:19.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/db/f2e7703791a1f32532618b82789ddddb7173b9e22d97e34cc11950d8e330/pypdf-6.5.0-py3-none-any.whl", hash = "sha256:9cef8002aaedeecf648dfd9ff1ce38f20ae8d88e2534fced6630038906440b25", size = 329560, upload-time = "2025-12-21T11:07:18.173Z" },
+]
+
+[[package]]
 name = "pyphen"
 version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1753,8 +1779,11 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "alembic-postgresql-enum" },
+    { name = "asn1crypto" },
     { name = "asyncpg" },
     { name = "cachetools" },
+    { name = "cryptography" },
+    { name = "endesive" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
@@ -1763,10 +1792,12 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "psycopg2-binary" },
     { name = "pydantic-settings" },
+    { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "reportlab" },
+    { name = "requests" },
     { name = "sqlalchemy" },
     { name = "weasyprint" },
 ]
@@ -1807,8 +1838,11 @@ test = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "alembic-postgresql-enum", specifier = ">=1.8.0" },
+    { name = "asn1crypto", specifier = ">=1.5.1" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "cachetools", specifier = ">=6.2.4" },
+    { name = "cryptography", specifier = ">=46.0.3" },
+    { name = "endesive", specifier = ">=2.19.2" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.123.10" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.4" },
@@ -1817,10 +1851,12 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pypdf", specifier = ">=6.5.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "reportlab", specifier = ">=4.4.7" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "sqlalchemy", specifier = ">=2.0.44" },
     { name = "weasyprint", specifier = ">=62.3" },
 ]
@@ -1868,6 +1904,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/a7/4600cb1cfc975a06552e8927844ddcb8fd90217e9a6068f5c7aa76c3f221/reportlab-4.4.7.tar.gz", hash = "sha256:41e8287af965e5996764933f3e75e7f363c3b6f252ba172f9429e81658d7b170", size = 3714000, upload-time = "2025-12-21T11:50:11.336Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/bf/a29507386366ab17306b187ad247dd78e4599be9032cb5f44c940f547fc0/reportlab-4.4.7-py3-none-any.whl", hash = "sha256:8fa05cbf468e0e76745caf2029a4770276edb3c8e86a0b71e0398926baf50673", size = 1954263, upload-time = "2025-12-21T11:50:08.93Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Implement PDF signing service using endesive library
- Add certificate generation, validation, and management utilities
- Integrate signing into admin sign_confirmation_response endpoint
- Add comprehensive certificate setup documentation
- Support PEM and P12/PFX certificate formats with chain support
- Add certificate validation endpoint

Signed PDFs are verifiable in standard PDF readers (Adobe Reader, Chrome, etc.) and maintain document integrity. Includes CLI tools for certificate management and comprehensive setup documentation.